### PR TITLE
Add support for Redis over SSL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ Support currently exists for:
 * memcached: ``'memcached://HOST:PORT'`` [#memcache]_
 * pymemcached: ``'pymemcached://HOST:PORT'`` For use with the `python-memcached`_ library. Useful if you're using Ubuntu <= 10.04.
 * djangopylibmc: ``'djangopylibmc://HOST:PORT'`` For use with SASL based setups such as Heroku.
-* redis: ``'redis://[USER:PASSWORD@]HOST:PORT[/DB]'`` or ``'redis:///PATH/TO/SOCKET[/DB]'`` For use with `django-redis`_.
-* hiredis: ``'hiredis://[USER:PASSWORD@]HOST:PORT[/DB]'`` or ``'hiredis:///PATH/TO/SOCKET[/DB]'`` For use with django-redis library using HiredisParser.
+* redis: ``'redis://[USER:PASSWORD@]HOST:PORT[/DB]'``, ``'redis:///PATH/TO/SOCKET[/DB]'``, or ``'rediss://[USER:PASSWORD@]HOST:PORT[/DB]'`` (for SSL). For use with `django-redis`_.
+* hiredis: ``'hiredis://[USER:PASSWORD@]HOST:PORT[/DB]'``, ``'hiredis:///PATH/TO/SOCKET[/DB]'``, or ``'hiredis://[USER:PASSWORD@]HOST:PORT[/DB]'`` (for SSL). For use with django-redis library using HiredisParser.
 * uwsgicache: ``'uwsgicache://[CACHENAME]'`` For use with `django-uwsgi-cache`_. Fallbacks to ``locmem`` if not running on uWSGI server.
 
 All cache urls support optional cache arguments by using a query string, e.g.: ``'memcached://HOST:PORT?key_prefix=site1'``. See the Django `cache arguments documentation`_.

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -51,3 +51,37 @@ def test_redis_with_password():
     assert config['BACKEND'] == 'django_redis.cache.RedisCache'
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['OPTIONS']['PASSWORD'] == 'redispass'
+
+
+#
+# REDIS (SSL)
+#
+
+def test_redis_ssl():
+    url = 'rediss://127.0.0.1:6379/0?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert config['LOCATION'] == 'rediss://127.0.0.1:6379/0'
+
+
+def test_redis_ssl_with_password():
+    url = 'rediss://:redispass@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert config['LOCATION'] == 'rediss://127.0.0.1:6379/0'
+    assert config['OPTIONS']['PASSWORD'] == 'redispass'
+
+
+#
+# HIREDIS (SSL)
+#
+
+def test_hiredis_ssl():
+    url = 'hirediss://127.0.0.1:6379/0?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'django_redis.cache.RedisCache'
+    assert config['LOCATION'] == 'rediss://127.0.0.1:6379/0'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'


### PR DESCRIPTION
This is required for certain cloud setups (DigitalOcean managed Redis, AWS ElastiCache).