### PR TITLE
special case for "file:" backend, allowing relative paths

### DIFF
--- a/django_cache_url/__init__.py
+++ b/django_cache_url/__init__.py
@@ -83,6 +83,9 @@ def parse(url):
         if url.scheme in ('memcached', 'pymemcached', 'djangopylibmc'):
             config['LOCATION'] = 'unix:' + path
 
+        elif url.scheme == "file":
+            config['LOCATION'] = path[1:]
+
         elif url.scheme in ('redis', 'hiredis'):
             match = re.match(r'.+?(?P<db>\d+)', path)
             if match:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,11 +25,18 @@ def test_dummy_url_returns_dummy_cache():
     assert config['BACKEND'] == 'django.core.cache.backends.dummy.DummyCache'
 
 
-def test_file_url_returns_file_cache_backend():
-    config = django_cache_url.parse('file:///herp')
+def test_file_url_returns_file_cache_backend_relative():
+    config = django_cache_url.parse('file:///herp/bar')
 
     assert config['BACKEND'] == 'django.core.cache.backends.filebased.FileBasedCache'
-    assert config['LOCATION'] == '/herp'
+    assert config['LOCATION'] == 'herp/bar'
+
+
+def test_file_url_returns_file_cache_backend_absolute():
+    config = django_cache_url.parse('file:////var/herp')
+
+    assert config['BACKEND'] == 'django.core.cache.backends.filebased.FileBasedCache'
+    assert config['LOCATION'] == '/var/herp'
 
 
 def test_locmem_url_returns_locmem_cache():


### PR DESCRIPTION
Resolves #9 

Seemed safer than to alter the `else` branch. Not sure, though.