### PR TITLE
Add support for hiredis scheme with django-redis-cache

### DIFF
--- a/django_cache_url/__init__.py
+++ b/django_cache_url/__init__.py
@@ -69,7 +69,7 @@ def parse(url):
         raise Exception(f'Unknown backend: "{url.scheme}"')
 
     lib = cache_args.get('LIB')
-    if url.scheme.startswith('redis') and lib in BACKENDS:
+    if 'redis' in url.scheme and lib in BACKENDS:
         backend = BACKENDS[lib]
 
     config['BACKEND'] = backend

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,8 @@ addopts =
     --cov-report html:htmlcov
     --cov-report xml
     --cov-fail-under=96
+    --cov-config=setup.cfg
     --cov=.
+
+[run]
+omit = venv/*

--- a/tests/test_django_redis_cache.py
+++ b/tests/test_django_redis_cache.py
@@ -105,3 +105,30 @@ def test_rediss_config_with_password():
 
     assert config['BACKEND'] == 'redis_cache.RedisCache'
     assert config['LOCATION'] == 'rediss://:mypassword@127.0.0.1:6379/0'
+
+
+def test_hiredis_config_with_db():
+    url = f'hiredis://127.0.0.1:6379/1?lib={redis_cache}'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'redis_cache.RedisCache'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379/1'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+def test_hiredis_config():
+    url = f'hiredis://127.0.0.1:6379/?lib={redis_cache}'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'redis_cache.RedisCache'
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+def test_hiredis_config_with_password():
+    url = f'hiredis://:mypassword@127.0.0.1:6379/?lib={redis_cache}'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'redis_cache.RedisCache'
+    assert config['LOCATION'] == 'redis://:mypassword@127.0.0.1:6379/0'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'


### PR DESCRIPTION
When using "?lib=redis-cache", the hiredis scheme was getting ignored.
I also added an additionnal coverage config so that people running this project in a venv like me won't have their venv dir included in coverage (and making it fail in local).