### PR TITLE
Add support for pymemache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ Support currently exists for:
 * file: ``'file:///PATH/TO/FILE'``
 * memcached: ``'memcached://HOST:PORT'`` [#memcache]_
 * pymemcached: ``'pymemcached://HOST:PORT'`` For use with the `python-memcached`_ library. Useful if you're using Ubuntu <= 10.04.
+* pymemcache: ``'pymemcache://HOST:PORT'`` For use with the `pymemcache`_ library.
 * djangopylibmc: ``'djangopylibmc://HOST:PORT'`` For use with SASL based setups such as Heroku.
 * redis: ``'redis://[USER:PASSWORD@]HOST:PORT[/DB]'`` or ``'redis:///PATH/TO/SOCKET[/DB]'`` For use with `django-redis`_. To use `django-redis-cache`_ just add ``?lib=redis-cache`` to the URL.
 * rediss: ``'rediss://[USER:PASSWORD@]HOST:PORT[/DB]'`` For use with `django-redis`_.
@@ -63,6 +64,7 @@ All cache urls support optional cache arguments by using a query string, e.g.: `
 .. _django-redis: https://github.com/niwibe/django-redis
 .. _django-redis-cache: https://github.com/sebleier/django-redis-cache
 .. _python-memcached: https://github.com/linsomniac/python-memcached
+.. _pymemcache: https://github.com/pinterest/pymemcache
 .. _cache arguments documentation: https://docs.djangoproject.com/en/dev/topics/cache/#cache-arguments
 .. _django-uwsgi-cache: https://github.com/ionelmc/django-uwsgi-cache
 

--- a/django_cache_url/__init__.py
+++ b/django_cache_url/__init__.py
@@ -18,6 +18,7 @@ urlparse.uses_netloc.append('memcached')
 urlparse.uses_netloc.append('elasticache')
 urlparse.uses_netloc.append('djangopylibmc')
 urlparse.uses_netloc.append('pymemcached')
+urlparse.uses_netloc.append('pymemcache')
 urlparse.uses_netloc.append('redis')
 urlparse.uses_netloc.append('hiredis')
 
@@ -34,6 +35,7 @@ BACKENDS = {
     'memcached': 'django.core.cache.backends.memcached.PyLibMCCache',
     'djangopylibmc': 'django_pylibmc.memcached.PyLibMCCache',
     'pymemcached': 'django.core.cache.backends.memcached.MemcachedCache',
+    'pymemcache': 'django.core.cache.backends.memcached.PyMemcacheCache',
     DJANGO_REDIS_CACHE: 'redis_cache.RedisCache',
     'redis': 'django_redis.cache.RedisCache',
     'rediss': 'django_redis.cache.RedisCache',
@@ -80,7 +82,7 @@ def parse(url):
 
     # File based
     if not url.netloc:
-        if url.scheme in ('memcached', 'pymemcached', 'djangopylibmc'):
+        if url.scheme in ('memcached', 'pymemcached', 'pymemcache', 'djangopylibmc'):
             config['LOCATION'] = 'unix:' + path
 
         elif url.scheme in ('redis', 'hiredis'):

--- a/tests/test_pymemcache.py
+++ b/tests/test_pymemcache.py
@@ -1,0 +1,22 @@
+import django_cache_url
+
+
+def test_pymemcache_url_returns_pymemcache_cache():
+    url = 'pymemcache://127.0.0.1:11211?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == 'django.core.cache.backends.memcached.PyMemcacheCache'
+    assert config['LOCATION'] == '127.0.0.1:11211'
+    assert config['KEY_PREFIX'] == 'site1'
+
+
+def test_pymemcache_url_multiple_locations():
+    url = 'pymemcache://127.0.0.1:11211,192.168.0.100:11211?key_prefix=site1'
+    config = django_cache_url.parse(url)
+    assert config['LOCATION'] == '127.0.0.1:11211;192.168.0.100:11211'
+
+
+def test_pymemcache_socket_url():
+    url = 'pymemcache:///path/to/socket/'
+    config = django_cache_url.parse(url)
+    assert config['LOCATION'] == 'unix:/path/to/socket/'


### PR DESCRIPTION
Referencing https://github.com/epicserve/django-cache-url/issues/14 

Added support for `django.core.cache.backends.memcached.PyMemcacheCache`.