### PR TITLE
Generated `unix:` url must include double slashes

### DIFF
--- a/django_cache_url/__init__.py
+++ b/django_cache_url/__init__.py
@@ -90,7 +90,7 @@ def parse(url):
     # File based
     if not url.netloc:
         if url.scheme in ('memcached', 'pymemcached', 'pymemcache', 'djangopylibmc'):
-            config['LOCATION'] = 'unix:' + path
+            config['LOCATION'] = 'unix://' + path
 
         elif url.scheme in ('redis', 'hiredis'):
             match = re.match(r'.+?(?P<db>\d+)', path)
@@ -99,7 +99,7 @@ def parse(url):
                 path = path[:path.rfind('/')]
             else:
                 db = '0'
-            config['LOCATION'] = 'unix:%s?db=%s' % (path, db)
+            config['LOCATION'] = 'unix://%s?db=%s' % (path, db)
         else:
             config['LOCATION'] = path
     # URL based

--- a/tests/test_memcached.py
+++ b/tests/test_memcached.py
@@ -19,7 +19,7 @@ def test_memcached_url_multiple_locations():
 def test_memcached_socket_url():
     url = 'memcached:///path/to/socket/'
     config = django_cache_url.parse(url)
-    assert config['LOCATION'] == 'unix:/path/to/socket/'
+    assert config['LOCATION'] == 'unix:///path/to/socket/'
 
 
 def test_elasticache_url():

--- a/tests/test_pymemcache.py
+++ b/tests/test_pymemcache.py
@@ -19,4 +19,4 @@ def test_pymemcache_url_multiple_locations():
 def test_pymemcache_socket_url():
     url = 'pymemcache:///path/to/socket/'
     config = django_cache_url.parse(url)
-    assert config['LOCATION'] == 'unix:/path/to/socket/'
+    assert config['LOCATION'] == 'unix:///path/to/socket/'

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -23,7 +23,7 @@ def test_hiredis_socket():
     config = django_cache_url.parse(url)
 
     assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
-    assert config['LOCATION'] == 'unix:/path/to/socket?db=1'
+    assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
@@ -43,7 +43,7 @@ def test_redis_socket():
     url = 'redis:///path/to/socket/1?key_prefix=site1'
     config = django_cache_url.parse(url)
 
-    assert config['LOCATION'] == 'unix:/path/to/socket?db=1'
+    assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
     assert 'OPTIONS' not in config
 
 


### PR DESCRIPTION
fixes #23