### PR TITLE
Update redis backend support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - run: |
-          pip install pytest coverage pytest-cov ${{ matrix.django-version }}
+          pip install pytest coverage pytest-cov mock ${{ matrix.django-version }}
           export PYTHONPATH=`pwd`:$PYTHONPATH
           pytest

--- a/README.rst
+++ b/README.rst
@@ -51,9 +51,9 @@ Support currently exists for:
 * pymemcached: ``'pymemcached://HOST:PORT'`` For use with the `python-memcached`_ library. Useful if you're using Ubuntu <= 10.04.
 * pymemcache: ``'pymemcache://HOST:PORT'`` For use with the `pymemcache`_ library.
 * djangopylibmc: ``'djangopylibmc://HOST:PORT'`` For use with SASL based setups such as Heroku.
-* redis: ``'redis://[USER:PASSWORD@]HOST:PORT[/DB]'`` or ``'redis:///PATH/TO/SOCKET[/DB]'`` For use with `django-redis`_. To use `django-redis-cache`_ just add ``?lib=redis-cache`` to the URL.
-* rediss: ``'rediss://[USER:PASSWORD@]HOST:PORT[/DB]'`` For use with `django-redis`_.
-* hiredis: ``'hiredis://[USER:PASSWORD@]HOST:PORT[/DB]'`` or ``'hiredis:///PATH/TO/SOCKET[/DB]'`` For use with django-redis library using HiredisParser.
+* redis: ``'redis://[USER:PASSWORD@]HOST:PORT[/DB]'`` or ``'redis://[USER:PASSWORD@]/PATH/TO/SOCKET[/DB]'`` If Django >= 4.0, the `native redis backend (redis-py)`_ will be used, otherwise for use with `django-redis`_. To use `django-redis-cache`_ just add ``?lib=redis-cache`` to the URL (it does not support ``USER`` field).
+* rediss: ``'rediss://[USER:PASSWORD@]HOST:PORT[/DB]'`` For use with `native redis backend (redis-py)`_ or `django-redis`_.
+* hiredis: ``'hiredis://[USER:PASSWORD@]HOST:PORT[/DB]'`` or ``'hiredis://[USER:PASSWORD@]/PATH/TO/SOCKET[/DB]'`` For use with `native redis backend (redis-py)`_ or `django-redis`_ library using HiredisParser.
 * uwsgicache: ``'uwsgicache://[CACHENAME]'`` For use with `django-uwsgi-cache`_. Fallbacks to ``locmem`` if not running on uWSGI server.
 
 All cache urls support optional cache arguments by using a query string, e.g.: ``'memcached://HOST:PORT?key_prefix=site1'``. See the Django `cache arguments documentation`_.
@@ -61,6 +61,7 @@ All cache urls support optional cache arguments by using a query string, e.g.: `
 .. [#memcache] To specify multiple instances, separate the the ``HOST:PORT``` pair
                by commas, e.g: ``'memcached://HOST1:PORT1,HOST2:PORT2``
 
+.. _native Redis backend (redis-py): https://docs.djangoproject.com/en/4.0/topics/cache/#redis
 .. _django-redis: https://github.com/niwibe/django-redis
 .. _django-redis-cache: https://github.com/sebleier/django-redis-cache
 .. _python-memcached: https://github.com/linsomniac/python-memcached

--- a/django_cache_url/__init__.py
+++ b/django_cache_url/__init__.py
@@ -119,6 +119,9 @@ def parse(url):
                     config['LOCATION'] = f'unix://{username}@{path}?db={db}'
                 if password != '':
                     config['LOCATION'] += f'&password={password}'
+
+                redis_options = parser_buildin_django_backend_options(cache_args, redis_options)
+
             elif backend == DJANGO_REDIS_CACHE_BACKEND:
                 # django-redis-cache socket connection:
                 # unix://[:password]@/path/to/socket.sock?db=0
@@ -160,6 +163,8 @@ def parse(url):
                 # redis://[[username]:[password]]@localhost:6379/0
                 if username != '' or password != '':
                     config['LOCATION'] = f'{scheme}://{username}:{password}@{url.hostname}:{port}/{db}'
+
+                redis_options = parser_buildin_django_backend_options(cache_args, redis_options)
 
             elif backend == DJANGO_REDIS_CACHE_BACKEND:
                 # django-redis-cache:
@@ -205,3 +210,13 @@ def parse(url):
     config.update(cache_args)
 
     return config
+
+
+def parser_buildin_django_backend_options(cache_args, redis_options):
+    if 'PARSER_CLASS' in cache_args:
+        redis_options['PARSER_CLASS'] = cache_args['PARSER_CLASS']
+    if 'POOL_CLASS' in cache_args:
+        redis_options['POOL_CLASS'] = cache_args['POOL_CLASS']
+    # native redis backend requires the keys in the `OPTIONS` to be lowercase
+    redis_options = {k.lower(): v for k, v in redis_options.items()}
+    return redis_options

--- a/django_cache_url/__init__.py
+++ b/django_cache_url/__init__.py
@@ -27,11 +27,13 @@ urlparse.uses_netloc.append('hiredis')
 DEFAULT_ENV = 'CACHE_URL'
 # TODO Remove as soon as Django 3.2 goes EOL
 BUILTIN_DJANGO_BACKEND = 'django.core.cache.backends.redis.RedisCache'
-EXTERNAL_DJANGO_BACKEND = 'django_redis.cache.RedisCache'
+
+DJANGO_REDIS_BACKEND = 'django_redis.cache.RedisCache'
 
 DJANGO_REDIS_CACHE_LIB_KEY = 'redis-cache'
 DJANGO_REDIS_CACHE_BACKEND = 'redis_cache.RedisCache'
-DJANGO_REDIS_BACKEND = EXTERNAL_DJANGO_BACKEND if VERSION[0] < 4 else BUILTIN_DJANGO_BACKEND
+
+DEFAULT_REDIS_BACKEND = DJANGO_REDIS_BACKEND if VERSION[0] < 4 else BUILTIN_DJANGO_BACKEND
 
 BACKENDS = {
     'db': 'django.core.cache.backends.db.DatabaseCache',
@@ -45,9 +47,9 @@ BACKENDS = {
     'pymemcached': 'django.core.cache.backends.memcached.MemcachedCache',
     'pymemcache': 'django.core.cache.backends.memcached.PyMemcacheCache',
     DJANGO_REDIS_CACHE_LIB_KEY: DJANGO_REDIS_CACHE_BACKEND,
-    'redis': DJANGO_REDIS_BACKEND,
-    'rediss': DJANGO_REDIS_BACKEND,
-    'hiredis': DJANGO_REDIS_BACKEND,
+    'redis': DEFAULT_REDIS_BACKEND,
+    'rediss': DEFAULT_REDIS_BACKEND,
+    'hiredis': DEFAULT_REDIS_BACKEND,
 }
 
 
@@ -105,7 +107,7 @@ def parse(url):
 
             username = url.username or ''
             password = url.password or ''
-            if backend == EXTERNAL_DJANGO_BACKEND:
+            if backend == DJANGO_REDIS_BACKEND:
                 # django-redis socket connection:
                 # unix://[[username]:[password]]@/path/to/socket.sock?db=0
                 if username != '' or password != '':
@@ -142,7 +144,7 @@ def parse(url):
             username = url.username or ''
             password = url.password or ''
 
-            if backend == EXTERNAL_DJANGO_BACKEND:
+            if backend == DJANGO_REDIS_BACKEND:
                 # django-redis:
                 # redis://[[username]:[password]]@localhost:6379/0
                 # as for the password: `OPTIONS` does not overwrite the password in the `LOCATION`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import sys
+import mock
+import pytest
+import importlib
+
+
+MODULE_NAME = 'django_cache_url'
+DJANGO_VERSION_3 = (3, 0, 0, "final", 0)
+DJANGO_VERSION_4 = (4, 0, 0, "final", 0)
+
+
+@pytest.fixture()
+def django_cache_url_dj3():
+    if MODULE_NAME in sys.modules:
+        del sys.modules[MODULE_NAME]
+    with mock.patch('django.VERSION', DJANGO_VERSION_3):
+        module = importlib.import_module(MODULE_NAME)
+        yield module
+        del sys.modules[MODULE_NAME]
+
+
+@pytest.fixture()
+def django_cache_url_dj4():
+    if MODULE_NAME in sys.modules:
+        del sys.modules[MODULE_NAME]
+    with mock.patch('django.VERSION', DJANGO_VERSION_4):
+        module = importlib.import_module(MODULE_NAME)
+        yield module
+        del sys.modules[MODULE_NAME]

--- a/tests/test_django_redis_cache.py
+++ b/tests/test_django_redis_cache.py
@@ -5,6 +5,7 @@ import django_cache_url
 redis_cache = django_cache_url.DJANGO_REDIS_CACHE_LIB_KEY
 
 
+# region REDIS url-base
 def test_basic_config():
     url = f'redis://127.0.0.1:6379/?lib={redis_cache}'
     config = django_cache_url.parse(url)
@@ -46,6 +47,20 @@ def test_basic_config_with_password():
     assert config['LOCATION'] == 'redis://:mypassword@127.0.0.1:6379/0'
 
 
+def test_basic_config_with_username():
+    url = f'redis://foo:@127.0.0.1:6379/?lib={redis_cache}'
+    with pytest.raises(Exception) as exc_info:
+        django_cache_url.parse(url)
+    assert str(exc_info.value).startswith('Username is not supported')
+
+
+def test_basic_config_with_username_password():
+    url = f'redis://foo:bar@127.0.0.1:6379/?lib={redis_cache}'
+    with pytest.raises(Exception) as exc_info:
+        django_cache_url.parse(url)
+    assert str(exc_info.value).startswith('Username is not supported')
+
+
 def test_basic_config_with_parser_class():
     url = f'redis://127.0.0.1:6379/?lib={redis_cache}&parser_class=redis.connection.HiredisParser'
     config = django_cache_url.parse(url)
@@ -83,8 +98,38 @@ def test_basic_config_with_connection_pool_class_kwargs():
     config = django_cache_url.parse(url)
     assert config['OPTIONS']['CONNECTION_POOL_CLASS_KWARGS']['timeout'] == 10
     assert 'max_connections' not in config['OPTIONS']['CONNECTION_POOL_CLASS_KWARGS']
+# endregion
 
 
+# region REDIS socket-base
+def test_basic_socket():
+    url = f'redis:///path/to/socket/1?lib={redis_cache}'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_CACHE_BACKEND
+
+    assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
+    assert 'OPTIONS' not in config
+
+
+def test_basic_socket_with_password():
+    url = f'redis://:bar@/path/to/socket/1?lib={redis_cache}'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_CACHE_BACKEND
+    assert config['LOCATION'] == 'unix://:bar@/path/to/socket?db=1'
+    assert 'OPTIONS' not in config
+
+
+def test_basic_socket_with_username():
+    url = f'redis://foo:@/path/to/socket/1?lib={redis_cache}'
+    with pytest.raises(Exception) as exc_info:
+        django_cache_url.parse(url)
+    assert str(exc_info.value).startswith('Username is not supported for unix socket connection')
+# endregion
+
+
+# region REDISS
 def test_rediss_config_with_db():
     url = f'rediss://127.0.0.1:6379/1?lib={redis_cache}'
     config = django_cache_url.parse(url)
@@ -107,8 +152,10 @@ def test_rediss_config_with_password():
 
     assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_CACHE_BACKEND
     assert config['LOCATION'] == 'rediss://:mypassword@127.0.0.1:6379/0'
+# endregion
 
 
+# region HIREDIS
 def test_hiredis_config_with_db():
     url = f'hiredis://127.0.0.1:6379/1?lib={redis_cache}'
     config = django_cache_url.parse(url)
@@ -134,30 +181,4 @@ def test_hiredis_config_with_password():
     assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_CACHE_BACKEND
     assert config['LOCATION'] == 'redis://:mypassword@127.0.0.1:6379/0'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
-
-
-# Socket connection
-def test_basic_socket():
-    url = f'redis:///path/to/socket/1?lib={redis_cache}'
-    config = django_cache_url.parse(url)
-
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_CACHE_BACKEND
-
-    assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
-    assert 'OPTIONS' not in config
-
-
-def test_basic_socket_with_password():
-    url = f'redis://:bar@/path/to/socket/1?lib={redis_cache}'
-    config = django_cache_url.parse(url)
-
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_CACHE_BACKEND
-    assert config['LOCATION'] == 'unix://:bar@/path/to/socket?db=1'
-    assert 'OPTIONS' not in config
-
-
-def test_basic_socket_with_username():
-    url = f'redis://foo:bar@/path/to/socket/1?lib={redis_cache}'
-    with pytest.raises(Exception) as exc_info:
-        django_cache_url.parse(url)
-    assert str(exc_info.value).startswith('Username is not supported for unix socket connection')
+# endregion

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -120,3 +120,47 @@ def test_redis_with_password_dj4():
     assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'redis://:redispass@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
+
+
+@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
+def test_redis_with_username_dj3():
+    importlib.reload(django_cache_url)
+    url = 'redis://foo:@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+
+
+@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
+def test_redis_with_username_dj4():
+    importlib.reload(django_cache_url)
+    url = 'redis://foo:@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'redis://foo:@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+
+
+@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
+def test_redis_with_username_password_dj3():
+    importlib.reload(django_cache_url)
+    url = 'redis://foo:bar@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
+    assert config['OPTIONS']['PASSWORD'] == 'bar'
+
+
+@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
+def test_redis_with_username_password_dj4():
+    importlib.reload(django_cache_url)
+    url = 'redis://foo:bar@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'redis://foo:bar@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -18,50 +18,6 @@ def test_hiredis_dj4(django_cache_url_dj4):
     assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
     assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
     assert config['OPTIONS']['pool_class'] == 'redis.BlockingConnectionPool'
-# endregion
-
-
-# region HIREDIS socket
-def test_hiredis_socket_dj3(django_cache_url_dj3):
-    url = 'hiredis:///path/to/socket/1?key_prefix=site1'
-    config = django_cache_url_dj3.parse(url)
-
-    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
-    assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
-    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
-
-
-def test_hiredis_socket_dj4(django_cache_url_dj4):
-    url = 'hiredis:///path/to/socket/1?key_prefix=site1'
-    config = django_cache_url_dj4.parse(url)
-
-    assert config['BACKEND'] == django_cache_url_dj4.DEFAULT_REDIS_BACKEND
-    assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
-    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
-    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
-
-
-def test_hiredis_socket_with_username_password_dj3(django_cache_url_dj3):
-    url = 'hiredis://foo:bar@/path/to/socket/1?key_prefix=site1'
-    config = django_cache_url_dj3.parse(url)
-
-    assert config['BACKEND'] == django_cache_url_dj3.DJANGO_REDIS_BACKEND
-    assert config['LOCATION'] == 'unix://foo:bar@/path/to/socket?db=1'
-    assert 'PASSWORD' not in config.get('OPTIONS', {})
-    assert config['KEY_PREFIX'] == 'site1'
-    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
-
-
-def test_hiredis_socket_with_username_password_dj4(django_cache_url_dj4):
-    url = 'hiredis://foo:bar@/path/to/socket/1?key_prefix=site1'
-    config = django_cache_url_dj4.parse(url)
-
-    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
-    assert config['LOCATION'] == 'unix://foo@/path/to/socket?db=1&password=bar'
-    assert 'PASSWORD' not in config.get('OPTIONS', {})
-    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
-    assert config['KEY_PREFIX'] == 'site1'
-    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
 def test_hiredis_with_password_dj3(django_cache_url_dj3):
@@ -124,6 +80,50 @@ def test_hiredis_with_username_password_dj4(django_cache_url_dj4):
     assert config['LOCATION'] == 'redis://foo:bar@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
     assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
+# endregion
+
+
+# region HIREDIS socket
+def test_hiredis_socket_dj3(django_cache_url_dj3):
+    url = 'hiredis:///path/to/socket/1?key_prefix=site1'
+    config = django_cache_url_dj3.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
+    assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+def test_hiredis_socket_dj4(django_cache_url_dj4):
+    url = 'hiredis:///path/to/socket/1?key_prefix=site1'
+    config = django_cache_url_dj4.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj4.DEFAULT_REDIS_BACKEND
+    assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
+    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
+
+
+def test_hiredis_socket_with_username_password_dj3(django_cache_url_dj3):
+    url = 'hiredis://foo:bar@/path/to/socket/1?key_prefix=site1'
+    config = django_cache_url_dj3.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj3.DJANGO_REDIS_BACKEND
+    assert config['LOCATION'] == 'unix://foo:bar@/path/to/socket?db=1'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert config['KEY_PREFIX'] == 'site1'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+def test_hiredis_socket_with_username_password_dj4(django_cache_url_dj4):
+    url = 'hiredis://foo:bar@/path/to/socket/1?key_prefix=site1'
+    config = django_cache_url_dj4.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'unix://foo@/path/to/socket?db=1&password=bar'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
+    assert config['KEY_PREFIX'] == 'site1'
     assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 # endregion
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -8,7 +8,9 @@ import django_cache_url
 #
 
 
-def test_hiredis():
+@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
+def test_hiredis_dj3():
+    importlib.reload(django_cache_url)
     url = 'hiredis://127.0.0.1:6379/0?key_prefix=site1'
     config = django_cache_url.parse(url)
 
@@ -17,13 +19,40 @@ def test_hiredis():
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
-def test_hiredis_socket():
+@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
+def test_hiredis_dj4():
+    importlib.reload(django_cache_url)
+    url = 'hiredis://127.0.0.1:6379/0?key_prefix=site1&pool_class=redis.BlockingConnectionPool'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
+    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
+    assert config['OPTIONS']['pool_class'] == 'redis.BlockingConnectionPool'
+
+
+@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
+def test_hiredis_socket_dj3():
+    importlib.reload(django_cache_url)
     url = 'hiredis:///path/to/socket/1?key_prefix=site1'
     config = django_cache_url.parse(url)
 
     assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
+def test_hiredis_socket_dj4():
+    importlib.reload(django_cache_url)
+    url = 'hiredis:///path/to/socket/1?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
+    assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
+    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
 @mock.patch('django.VERSION', (3, 0, 0, "final", 0))
@@ -48,8 +77,9 @@ def test_hiredis_socket_with_username_password_dj4():
     assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'unix://foo@/path/to/socket?db=1&password=bar'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
     assert config['KEY_PREFIX'] == 'site1'
-    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
 @mock.patch('django.VERSION', (3, 0, 0, "final", 0))
@@ -73,7 +103,8 @@ def test_hiredis_with_password_dj4():
     assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'redis://:redispass@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
-    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
 @mock.patch('django.VERSION', (3, 0, 0, "final", 0))
@@ -97,7 +128,8 @@ def test_hiredis_with_username_dj4():
     assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'redis://foo:@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
-    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
 @mock.patch('django.VERSION', (3, 0, 0, "final", 0))
@@ -121,7 +153,8 @@ def test_hiredis_with_username_password_dj4():
     assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'redis://foo:bar@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
-    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+    assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
 #

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,80 +1,62 @@
-import mock
-import importlib
 
-import django_cache_url
-
-#
-# HIREDIS
-#
-
-
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_hiredis_dj3():
-    importlib.reload(django_cache_url)
+# region HIREDIS url
+def test_hiredis_dj3(django_cache_url_dj3):
     url = 'hiredis://127.0.0.1:6379/0?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_hiredis_dj4():
-    importlib.reload(django_cache_url)
+def test_hiredis_dj4(django_cache_url_dj4):
     url = 'hiredis://127.0.0.1:6379/0?key_prefix=site1&pool_class=redis.BlockingConnectionPool'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj4.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
     assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
     assert config['OPTIONS']['pool_class'] == 'redis.BlockingConnectionPool'
+# endregion
 
 
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_hiredis_socket_dj3():
-    importlib.reload(django_cache_url)
+# region HIREDIS socket
+def test_hiredis_socket_dj3(django_cache_url_dj3):
     url = 'hiredis:///path/to/socket/1?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_hiredis_socket_dj4():
-    importlib.reload(django_cache_url)
+def test_hiredis_socket_dj4(django_cache_url_dj4):
     url = 'hiredis:///path/to/socket/1?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj4.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
     assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
     assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_hiredis_socket_with_username_password_dj3():
-    importlib.reload(django_cache_url)
+def test_hiredis_socket_with_username_password_dj3(django_cache_url_dj3):
     url = 'hiredis://foo:bar@/path/to/socket/1?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj3.DJANGO_REDIS_BACKEND
     assert config['LOCATION'] == 'unix://foo:bar@/path/to/socket?db=1'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
     assert config['KEY_PREFIX'] == 'site1'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_hiredis_socket_with_username_password_dj4():
-    importlib.reload(django_cache_url)
+def test_hiredis_socket_with_username_password_dj4(django_cache_url_dj4):
     url = 'hiredis://foo:bar@/path/to/socket/1?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'unix://foo@/path/to/socket?db=1&password=bar'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
     assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
@@ -82,216 +64,199 @@ def test_hiredis_socket_with_username_password_dj4():
     assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_hiredis_with_password_dj3():
-    importlib.reload(django_cache_url)
+def test_hiredis_with_password_dj3(django_cache_url_dj3):
     url = 'hiredis://:redispass@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['OPTIONS']['PASSWORD'] == 'redispass'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_hiredis_with_password_dj4():
-    importlib.reload(django_cache_url)
+def test_hiredis_with_password_dj4(django_cache_url_dj4):
     url = 'hiredis://:redispass@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'redis://:redispass@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
     assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
     assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_hiredis_with_username_dj3():
-    importlib.reload(django_cache_url)
+def test_hiredis_with_username_dj3(django_cache_url_dj3):
     url = 'hiredis://foo:@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_hiredis_with_username_dj4():
-    importlib.reload(django_cache_url)
+def test_hiredis_with_username_dj4(django_cache_url_dj4):
     url = 'hiredis://foo:@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'redis://foo:@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
     assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
     assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_hiredis_with_username_password_dj3():
-    importlib.reload(django_cache_url)
+def test_hiredis_with_username_password_dj3(django_cache_url_dj3):
     url = 'hiredis://foo:bar@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
     assert config['OPTIONS']['PASSWORD'] == 'bar'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_hiredis_with_username_password_dj4():
-    importlib.reload(django_cache_url)
+def test_hiredis_with_username_password_dj4(django_cache_url_dj4):
     url = 'hiredis://foo:bar@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'redis://foo:bar@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
     assert 'PARSER_CLASS' not in config.get('OPTIONS', {})
     assert config['OPTIONS']['parser_class'] == 'redis.connection.HiredisParser'
+# endregion
 
 
-#
-# REDIS
-#
-
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_redis_dj3():
-    importlib.reload(django_cache_url)
+# region REDIS url
+def test_redis_dj3(django_cache_url_dj3):
     url = 'redis://127.0.0.1:6379/0?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj3.DJANGO_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['KEY_PREFIX'] == 'site1'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_redis_dj4():
-    importlib.reload(django_cache_url)
+def test_redis_dj4(django_cache_url_dj4):
     url = 'redis://127.0.0.1:6379/0?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['KEY_PREFIX'] == 'site1'
 
 
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_redis_socket_dj3():
-    importlib.reload(django_cache_url)
+def test_redis_with_password_dj3(django_cache_url_dj3):
+    url = 'redis://:redispass@127.0.0.1:6379/0'
+    config = django_cache_url_dj3.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
+    assert config['OPTIONS']['PASSWORD'] == 'redispass'
+
+
+def test_redis_with_password_dj4(django_cache_url_dj4):
+    url = 'redis://:redispass@127.0.0.1:6379/0'
+    config = django_cache_url_dj4.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'redis://:redispass@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+
+
+def test_redis_with_username_dj3(django_cache_url_dj3):
+    url = 'redis://foo:@127.0.0.1:6379/0'
+    config = django_cache_url_dj3.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
+    assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+
+
+def test_redis_with_username_dj4(django_cache_url_dj4):
+    url = 'redis://foo:@127.0.0.1:6379/0'
+    config = django_cache_url_dj4.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'redis://foo:@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+
+
+def test_redis_with_username_password_dj3(django_cache_url_dj3):
+    url = 'redis://foo:bar@127.0.0.1:6379/0'
+    config = django_cache_url_dj3.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj3.DEFAULT_REDIS_BACKEND
+    assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
+    assert config['OPTIONS']['PASSWORD'] == 'bar'
+
+
+def test_redis_with_username_password_dj4(django_cache_url_dj4):
+    url = 'redis://foo:bar@127.0.0.1:6379/0'
+    config = django_cache_url_dj4.parse(url)
+
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'redis://foo:bar@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+# endregion
+
+
+# region REDIS socket
+def test_redis_socket_dj3(django_cache_url_dj3):
     url = 'redis:///path/to/socket/1?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj3.DJANGO_REDIS_BACKEND
     assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
     assert 'OPTIONS' not in config
     assert config['KEY_PREFIX'] == 'site1'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_redis_socket_dj4():
-    importlib.reload(django_cache_url)
+def test_redis_socket_dj4(django_cache_url_dj4):
     url = 'redis:///path/to/socket/1?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
     assert 'OPTIONS' not in config
     assert config['KEY_PREFIX'] == 'site1'
 
 
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_redis_socket_with_username_password_dj3():
-    importlib.reload(django_cache_url)
+def test_redis_socket_with_username_password_dj3(django_cache_url_dj3):
     url = 'redis://foo:bar@/path/to/socket/1?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj3.DJANGO_REDIS_BACKEND
     assert config['LOCATION'] == 'unix://foo:bar@/path/to/socket?db=1'
     assert 'OPTIONS' not in config
     assert config['KEY_PREFIX'] == 'site1'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_redis_socket_with_username_password_dj4():
-    importlib.reload(django_cache_url)
+def test_redis_socket_with_username_password_dj4(django_cache_url_dj4):
     url = 'redis://foo:bar@/path/to/socket/1?key_prefix=site1'
-    config = django_cache_url.parse(url)
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
     assert config['LOCATION'] == 'unix://foo@/path/to/socket?db=1&password=bar'
     assert 'OPTIONS' not in config
     assert config['KEY_PREFIX'] == 'site1'
+# endregion
 
 
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_redis_with_password_dj3():
-    importlib.reload(django_cache_url)
-    url = 'redis://:redispass@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
+# region REDISS
+def test_rediss_dj3(django_cache_url_dj3):
+    url = 'rediss://127.0.0.1:6379'
+    config = django_cache_url_dj3.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
-    assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
-    assert config['OPTIONS']['PASSWORD'] == 'redispass'
+    assert config['BACKEND'] == django_cache_url_dj3.DJANGO_REDIS_BACKEND
+    assert config['LOCATION'] == 'rediss://127.0.0.1:6379/0'
 
 
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_redis_with_password_dj4():
-    importlib.reload(django_cache_url)
-    url = 'redis://:redispass@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
+def test_rediss_dj4(django_cache_url_dj4):
+    url = 'rediss://127.0.0.1:6379'
+    config = django_cache_url_dj4.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
-    assert config['LOCATION'] == 'redis://:redispass@127.0.0.1:6379/0'
-    assert 'PASSWORD' not in config.get('OPTIONS', {})
-
-
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_redis_with_username_dj3():
-    importlib.reload(django_cache_url)
-    url = 'redis://foo:@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
-
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
-    assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
-    assert 'PASSWORD' not in config.get('OPTIONS', {})
-
-
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_redis_with_username_dj4():
-    importlib.reload(django_cache_url)
-    url = 'redis://foo:@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
-
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
-    assert config['LOCATION'] == 'redis://foo:@127.0.0.1:6379/0'
-    assert 'PASSWORD' not in config.get('OPTIONS', {})
-
-
-@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_redis_with_username_password_dj3():
-    importlib.reload(django_cache_url)
-    url = 'redis://foo:bar@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
-
-    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
-    assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
-    assert config['OPTIONS']['PASSWORD'] == 'bar'
-
-
-@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_redis_with_username_password_dj4():
-    importlib.reload(django_cache_url)
-    url = 'redis://foo:bar@127.0.0.1:6379/0'
-    config = django_cache_url.parse(url)
-
-    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
-    assert config['LOCATION'] == 'redis://foo:bar@127.0.0.1:6379/0'
-    assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert config['BACKEND'] == django_cache_url_dj4.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'rediss://127.0.0.1:6379/0'
+# endregion

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -12,7 +12,7 @@ def test_hiredis():
     url = 'hiredis://127.0.0.1:6379/0?key_prefix=site1'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
@@ -21,7 +21,7 @@ def test_hiredis_socket():
     url = 'hiredis:///path/to/socket/1?key_prefix=site1'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
@@ -32,7 +32,7 @@ def test_hiredis_socket_with_username_password_dj3():
     url = 'hiredis://foo:bar@/path/to/socket/1?key_prefix=site1'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.EXTERNAL_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
     assert config['LOCATION'] == 'unix://foo:bar@/path/to/socket?db=1'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
     assert config['KEY_PREFIX'] == 'site1'
@@ -58,7 +58,7 @@ def test_hiredis_with_password_dj3():
     url = 'hiredis://:redispass@127.0.0.1:6379/0'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['OPTIONS']['PASSWORD'] == 'redispass'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
@@ -82,7 +82,7 @@ def test_hiredis_with_username_dj3():
     url = 'hiredis://foo:@127.0.0.1:6379/0'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
@@ -106,7 +106,7 @@ def test_hiredis_with_username_password_dj3():
     url = 'hiredis://foo:bar@127.0.0.1:6379/0'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
     assert config['OPTIONS']['PASSWORD'] == 'bar'
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
@@ -134,7 +134,7 @@ def test_redis_dj3():
     url = 'redis://127.0.0.1:6379/0?key_prefix=site1'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.EXTERNAL_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['KEY_PREFIX'] == 'site1'
 
@@ -156,7 +156,7 @@ def test_redis_socket_dj3():
     url = 'redis:///path/to/socket/1?key_prefix=site1'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.EXTERNAL_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
     assert config['LOCATION'] == 'unix:///path/to/socket?db=1'
     assert 'OPTIONS' not in config
     assert config['KEY_PREFIX'] == 'site1'
@@ -180,7 +180,7 @@ def test_redis_socket_with_username_password_dj3():
     url = 'redis://foo:bar@/path/to/socket/1?key_prefix=site1'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.EXTERNAL_DJANGO_BACKEND
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
     assert config['LOCATION'] == 'unix://foo:bar@/path/to/socket?db=1'
     assert 'OPTIONS' not in config
     assert config['KEY_PREFIX'] == 'site1'
@@ -204,7 +204,7 @@ def test_redis_with_password_dj3():
     url = 'redis://:redispass@127.0.0.1:6379/0'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
     assert config['OPTIONS']['PASSWORD'] == 'redispass'
 
@@ -226,7 +226,7 @@ def test_redis_with_username_dj3():
     url = 'redis://foo:@127.0.0.1:6379/0'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
     assert 'PASSWORD' not in config.get('OPTIONS', {})
 
@@ -248,7 +248,7 @@ def test_redis_with_username_password_dj3():
     url = 'redis://foo:bar@127.0.0.1:6379/0'
     config = django_cache_url.parse(url)
 
-    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['BACKEND'] == django_cache_url.DEFAULT_REDIS_BACKEND
     assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
     assert config['OPTIONS']['PASSWORD'] == 'bar'
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -26,6 +26,104 @@ def test_hiredis_socket():
     assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
 
 
+@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
+def test_hiredis_socket_with_username_password_dj3():
+    importlib.reload(django_cache_url)
+    url = 'hiredis://foo:bar@/path/to/socket/1?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.EXTERNAL_DJANGO_BACKEND
+    assert config['LOCATION'] == 'unix://foo:bar@/path/to/socket?db=1'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert config['KEY_PREFIX'] == 'site1'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
+def test_hiredis_socket_with_username_password_dj4():
+    importlib.reload(django_cache_url)
+    url = 'hiredis://foo:bar@/path/to/socket/1?key_prefix=site1'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'unix://foo@/path/to/socket?db=1&password=bar'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert config['KEY_PREFIX'] == 'site1'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
+def test_hiredis_with_password_dj3():
+    importlib.reload(django_cache_url)
+    url = 'hiredis://:redispass@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['LOCATION'] == 'redis://127.0.0.1:6379/0'
+    assert config['OPTIONS']['PASSWORD'] == 'redispass'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
+def test_hiredis_with_password_dj4():
+    importlib.reload(django_cache_url)
+    url = 'hiredis://:redispass@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'redis://:redispass@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
+def test_hiredis_with_username_dj3():
+    importlib.reload(django_cache_url)
+    url = 'hiredis://foo:@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
+def test_hiredis_with_username_dj4():
+    importlib.reload(django_cache_url)
+    url = 'hiredis://foo:@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'redis://foo:@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+@mock.patch('django.VERSION', (3, 0, 0, "final", 0))
+def test_hiredis_with_username_password_dj3():
+    importlib.reload(django_cache_url)
+    url = 'hiredis://foo:bar@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.DJANGO_REDIS_BACKEND
+    assert config['LOCATION'] == 'redis://foo@127.0.0.1:6379/0'
+    assert config['OPTIONS']['PASSWORD'] == 'bar'
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
+@mock.patch('django.VERSION', (4, 0, 0, "final", 0))
+def test_hiredis_with_username_password_dj4():
+    importlib.reload(django_cache_url)
+    url = 'hiredis://foo:bar@127.0.0.1:6379/0'
+    config = django_cache_url.parse(url)
+
+    assert config['BACKEND'] == django_cache_url.BUILTIN_DJANGO_BACKEND
+    assert config['LOCATION'] == 'redis://foo:bar@127.0.0.1:6379/0'
+    assert 'PASSWORD' not in config.get('OPTIONS', {})
+    assert config['OPTIONS']['PARSER_CLASS'] == 'redis.connection.HiredisParser'
+
+
 #
 # REDIS
 #
@@ -77,7 +175,7 @@ def test_redis_socket_dj4():
 
 
 @mock.patch('django.VERSION', (3, 0, 0, "final", 0))
-def test_redis_socket_with_auth_dj3():
+def test_redis_socket_with_username_password_dj3():
     importlib.reload(django_cache_url)
     url = 'redis://foo:bar@/path/to/socket/1?key_prefix=site1'
     config = django_cache_url.parse(url)
@@ -89,7 +187,7 @@ def test_redis_socket_with_auth_dj3():
 
 
 @mock.patch('django.VERSION', (4, 0, 0, "final", 0))
-def test_redis_socket_with_auth_dj4():
+def test_redis_socket_with_username_password_dj4():
     importlib.reload(django_cache_url)
     url = 'redis://foo:bar@/path/to/socket/1?key_prefix=site1'
     config = django_cache_url.parse(url)


### PR DESCRIPTION
### feat: 

- `native django redis-py`, `django-redis` backend based on url connection: add `USER` field for authentication
- `native django redis-py`, `django-redis` backend based on socket connection: add `USER` and `PASSWORD` field for authentication
- `django-redis-cache` backend: throw exception when `USER` field is set
- `test_redis.py` file: replace pytest.mark.skipif with pytest.fixture and mock, add `conftest.py` file which provides `django_cache_url_dj3` and `django_cache_url_dj4`, two mocked modules as fixtures, for each test function. 

### fix: 

- `native django redis-py` backend:  covert the keys in the OPTIONS to lower case
- uniform redis backends name:

```python
# native django redis-py backend (Unchanged): 
BUILTIN_DJANGO_BACKEND = 'django.core.cache.backends.redis.RedisCache' 

# django-redis backend (Add a new variable)
DJANGO_REDIS_BACKEND = 'django_redis.cache.RedisCache'

# django-redis-cache (Unchanged): 
DJANGO_REDIS_CACHE_LIB_KEY = 'redis-cache'
DJANGO_REDIS_CACHE_BACKEND = 'redis_cache.RedisCache'

# default redis backend, depend on django version (Replace DJANGO_REDIS_BACKEND with DEFAULT_REDIS_BACKEND)
DEFAULT_REDIS_BACKEND = DJANGO_REDIS_BACKEND if VERSION[0] < 4 else BUILTIN_DJANGO_BACKEND
```

### docs:
- `readme.rst` file: update `redis`, `rediss`, `hiredis` usage about authentication and native redis backend 

------------
### More information about available schemes of different redis backends

- [native redis backend in Django 4](https://docs.djangoproject.com/en/4.1/topics/cache/#redis) and [redis-py](https://redis-py.readthedocs.io/en/stable/connections.html#redis.connection.ConnectionPool.from_url)
- [django-redis](https://github.com/jazzband/django-redis#configure-as-cache-backend)
- [django-redis-cache](https://django-redis-cache.readthedocs.io/en/latest/advanced_configuration.html#location-schemes)